### PR TITLE
#28: Fix System.Linq not imported for Enumerable.Empty<>()

### DIFF
--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/BoolParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/BoolParameterTest.cs
@@ -11,18 +11,20 @@ public class BoolParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class BoolParameterTestBuilder : DomainTestBuilderBase<BoolParameterTest>
-{
-    public BoolParameterTestBuilder WithId(bool id)
-    {
-        FillConstructorWith(nameof(id), id);
-        return this;
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class BoolParameterTestBuilder : DomainTestBuilderBase<BoolParameterTest>
+               {
+                   public BoolParameterTestBuilder WithId(bool id)
+                   {
+                       FillConstructorWith(nameof(id), id);
+                       return this;
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/DictionaryParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/DictionaryParameterTest.cs
@@ -11,24 +11,26 @@ public class DictionaryParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class DictionaryParameterTestBuilder : DomainTestBuilderBase<DictionaryParameterTest>
-{
-    public DictionaryParameterTestBuilder WithIds(Dictionary<int, string> ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
-
-    public DictionaryParameterTestBuilder WithEmptyIds()
-    {
-        return WithIds(new Dictionary<int, string>());
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class DictionaryParameterTestBuilder : DomainTestBuilderBase<DictionaryParameterTest>
+               {
+                   public DictionaryParameterTestBuilder WithIds(Dictionary<int, string> ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
+               
+                   public DictionaryParameterTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(new Dictionary<int, string>());
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/DoubleGenericInEnumerableParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/DoubleGenericInEnumerableParameterTest.cs
@@ -13,25 +13,28 @@ public class DoubleGenericInEnumerableParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using System.Linq;
+               using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class DoubleGenericInEnumerableParameterTestBuilder : DomainTestBuilderBase<DoubleGenericInEnumerableParameterTest>
-{
-    public DoubleGenericInEnumerableParameterTestBuilder WithIds(IEnumerable<DoubleGeneric<char, long>> ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class DoubleGenericInEnumerableParameterTestBuilder : DomainTestBuilderBase<DoubleGenericInEnumerableParameterTest>
+               {
+                   public DoubleGenericInEnumerableParameterTestBuilder WithIds(IEnumerable<DoubleGeneric<char, long>> ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
 
-    public DoubleGenericInEnumerableParameterTestBuilder WithEmptyIds()
-    {
-        return WithIds(Enumerable.Empty<DoubleGeneric<char, long>>());
-    }
-}";
+                   public DoubleGenericInEnumerableParameterTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(Enumerable.Empty<DoubleGeneric<char, long>>());
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/DoubleGenericParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/DoubleGenericParameterTest.cs
@@ -13,19 +13,21 @@ public class DoubleGenericParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class DoubleGenericParameterTestBuilder : DomainTestBuilderBase<DoubleGenericParameterTest>
-{
-    public DoubleGenericParameterTestBuilder WithIds(DoubleGeneric<char, decimal> ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class DoubleGenericParameterTestBuilder : DomainTestBuilderBase<DoubleGenericParameterTest>
+               {
+                   public DoubleGenericParameterTestBuilder WithIds(DoubleGeneric<char, decimal> ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/DuplicatedCtorParameterTypesTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/DuplicatedCtorParameterTypesTest.cs
@@ -13,36 +13,39 @@ public class DuplicatedCtorParameterTypesTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using System.Linq;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class DuplicatedCtorParameterTypesTestBuilder : DomainTestBuilderBase<DuplicatedCtorParameterTypesTest>
-{
-    public DuplicatedCtorParameterTypesTestBuilder WithIds(int ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class DuplicatedCtorParameterTypesTestBuilder : DomainTestBuilderBase<DuplicatedCtorParameterTypesTest>
+               {
+                   public DuplicatedCtorParameterTypesTestBuilder WithIds(int ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
 
-    public DuplicatedCtorParameterTypesTestBuilder WithId(int id)
-    {
-        FillConstructorWith(nameof(id), id);
-        return this;
-    }
+                   public DuplicatedCtorParameterTypesTestBuilder WithId(int id)
+                   {
+                       FillConstructorWith(nameof(id), id);
+                       return this;
+                   }
 
-    public DuplicatedCtorParameterTypesTestBuilder WithIds(IEnumerable<char> ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
+                   public DuplicatedCtorParameterTypesTestBuilder WithIds(IEnumerable<char> ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
 
-    public DuplicatedCtorParameterTypesTestBuilder WithEmptyIds()
-    {
-        return WithIds(Enumerable.Empty<char>());
-    }
-}";
+                   public DuplicatedCtorParameterTypesTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(Enumerable.Empty<char>());
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/DuplicatedCtorParametersTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/DuplicatedCtorParametersTest.cs
@@ -16,30 +16,33 @@ public class DuplicatedCtorParametersTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using System.Linq;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class DuplicatedCtorParametersTestBuilder : DomainTestBuilderBase<DuplicatedCtorParametersTest>
-{
-    public DuplicatedCtorParametersTestBuilder WithIds(IEnumerable<char> ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class DuplicatedCtorParametersTestBuilder : DomainTestBuilderBase<DuplicatedCtorParametersTest>
+               {
+                   public DuplicatedCtorParametersTestBuilder WithIds(IEnumerable<char> ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
 
-    public DuplicatedCtorParametersTestBuilder WithEmptyIds()
-    {
-        return WithIds(Enumerable.Empty<char>());
-    }
+                   public DuplicatedCtorParametersTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(Enumerable.Empty<char>());
+                   }
 
-    public DuplicatedCtorParametersTestBuilder WithId(int id)
-    {
-        FillConstructorWith(nameof(id), id);
-        return this;
-    }
-}";
+                   public DuplicatedCtorParametersTestBuilder WithId(int id)
+                   {
+                       FillConstructorWith(nameof(id), id);
+                       return this;
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/EnumerableInEnumerableParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/EnumerableInEnumerableParameterTest.cs
@@ -11,24 +11,27 @@ public class EnumerableInEnumerableParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using System.Linq;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class EnumerableInEnumerableParameterTestBuilder : DomainTestBuilderBase<EnumerableInEnumerableParameterTest>
-{
-    public EnumerableInEnumerableParameterTestBuilder WithIds(IEnumerable<IEnumerable<int>> ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
-
-    public EnumerableInEnumerableParameterTestBuilder WithEmptyIds()
-    {
-        return WithIds(Enumerable.Empty<IEnumerable<int>>());
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class EnumerableInEnumerableParameterTestBuilder : DomainTestBuilderBase<EnumerableInEnumerableParameterTest>
+               {
+                   public EnumerableInEnumerableParameterTestBuilder WithIds(IEnumerable<IEnumerable<int>> ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
+               
+                   public EnumerableInEnumerableParameterTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(Enumerable.Empty<IEnumerable<int>>());
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/EnumerableInListParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/EnumerableInListParameterTest.cs
@@ -11,24 +11,26 @@ public class EnumerableInListParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class EnumerableInListParameterTestBuilder : DomainTestBuilderBase<EnumerableInListParameterTest>
-{
-    public EnumerableInListParameterTestBuilder WithIds(List<IEnumerable<int>> ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class EnumerableInListParameterTestBuilder : DomainTestBuilderBase<EnumerableInListParameterTest>
+               {
+                   public EnumerableInListParameterTestBuilder WithIds(List<IEnumerable<int>> ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
 
-    public EnumerableInListParameterTestBuilder WithEmptyIds()
-    {
-        return WithIds(new List<IEnumerable<int>>());
-    }
-}";
+                   public EnumerableInListParameterTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(new List<IEnumerable<int>>());
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/EnumerableParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/EnumerableParameterTest.cs
@@ -11,24 +11,27 @@ public class EnumerableParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using System.Linq;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class EnumerableParameterTestBuilder : DomainTestBuilderBase<EnumerableParameterTest>
-{
-    public EnumerableParameterTestBuilder WithIds(IEnumerable<int> ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class EnumerableParameterTestBuilder : DomainTestBuilderBase<EnumerableParameterTest>
+               {
+                   public EnumerableParameterTestBuilder WithIds(IEnumerable<int> ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
 
-    public EnumerableParameterTestBuilder WithEmptyIds()
-    {
-        return WithIds(Enumerable.Empty<int>());
-    }
-}";
+                   public EnumerableParameterTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(Enumerable.Empty<int>());
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/InheritFromIEnumerableWithStandardCtorParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/InheritFromIEnumerableWithStandardCtorParameterTest.cs
@@ -13,23 +13,25 @@ public class InheritFromIEnumerableWithStandardCtorParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class InheritFromIEnumerableWithStandardCtorParameterTestBuilder : DomainTestBuilderBase<InheritFromIEnumerableWithStandardCtorParameterTest>
-{
-    public InheritFromIEnumerableWithStandardCtorParameterTestBuilder WithIds(InheritFromIEnumerableWithStandardCtor ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class InheritFromIEnumerableWithStandardCtorParameterTestBuilder : DomainTestBuilderBase<InheritFromIEnumerableWithStandardCtorParameterTest>
+               {
+                   public InheritFromIEnumerableWithStandardCtorParameterTestBuilder WithIds(InheritFromIEnumerableWithStandardCtor ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
 
-    public InheritFromIEnumerableWithStandardCtorParameterTestBuilder WithEmptyIds()
-    {
-        return WithIds(new InheritFromIEnumerableWithStandardCtor());
-    }
-}";
+                   public InheritFromIEnumerableWithStandardCtorParameterTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(new InheritFromIEnumerableWithStandardCtor());
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/InheritFromIEnumerableWithoutStandardCtorParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/InheritFromIEnumerableWithoutStandardCtorParameterTest.cs
@@ -13,18 +13,20 @@ public class InheritFromIEnumerableWithoutStandardCtorParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class InheritFromIEnumerableWithoutStandardCtorParameterTestBuilder : DomainTestBuilderBase<InheritFromIEnumerableWithoutStandardCtorParameterTest>
-{
-    public InheritFromIEnumerableWithoutStandardCtorParameterTestBuilder WithIds(InheritFromIEnumerableWithoutStandardCtor ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class InheritFromIEnumerableWithoutStandardCtorParameterTestBuilder : DomainTestBuilderBase<InheritFromIEnumerableWithoutStandardCtorParameterTest>
+               {
+                   public InheritFromIEnumerableWithoutStandardCtorParameterTestBuilder WithIds(InheritFromIEnumerableWithoutStandardCtor ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/IntParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/IntParameterTest.cs
@@ -11,18 +11,20 @@ public class IntParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class IntParameterTestBuilder : DomainTestBuilderBase<IntParameterTest>
-{
-    public IntParameterTestBuilder WithId(int id)
-    {
-        FillConstructorWith(nameof(id), id);
-        return this;
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class IntParameterTestBuilder : DomainTestBuilderBase<IntParameterTest>
+               {
+                   public IntParameterTestBuilder WithId(int id)
+                   {
+                       FillConstructorWith(nameof(id), id);
+                       return this;
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/ListInEnumerableParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/ListInEnumerableParameterTest.cs
@@ -11,24 +11,27 @@ public class ListInEnumerableParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using System.Linq;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class ListInEnumerableParameterTestBuilder : DomainTestBuilderBase<ListInEnumerableParameterTest>
-{
-    public ListInEnumerableParameterTestBuilder WithIds(IEnumerable<List<int>?> ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class ListInEnumerableParameterTestBuilder : DomainTestBuilderBase<ListInEnumerableParameterTest>
+               {
+                   public ListInEnumerableParameterTestBuilder WithIds(IEnumerable<List<int>?> ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
 
-    public ListInEnumerableParameterTestBuilder WithEmptyIds()
-    {
-        return WithIds(Enumerable.Empty<List<int>?>());
-    }
-}";
+                   public ListInEnumerableParameterTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(Enumerable.Empty<List<int>?>());
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/ListParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/ListParameterTest.cs
@@ -11,24 +11,26 @@ public class ListParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class ListParameterTestBuilder : DomainTestBuilderBase<ListParameterTest>
-{
-    public ListParameterTestBuilder WithIds(List<int> ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class ListParameterTestBuilder : DomainTestBuilderBase<ListParameterTest>
+               {
+                   public ListParameterTestBuilder WithIds(List<int> ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
 
-    public ListParameterTestBuilder WithEmptyIds()
-    {
-        return WithIds(new List<int>());
-    }
-}";
+                   public ListParameterTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(new List<int>());
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/NullableDictionaryParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/NullableDictionaryParameterTest.cs
@@ -11,29 +11,31 @@ public class NullableDictionaryParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class NullableDictionaryParameterTestBuilder : DomainTestBuilderBase<NullableDictionaryParameterTest>
-{
-    public NullableDictionaryParameterTestBuilder WithIds(Dictionary<int, string>? ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class NullableDictionaryParameterTestBuilder : DomainTestBuilderBase<NullableDictionaryParameterTest>
+               {
+                   public NullableDictionaryParameterTestBuilder WithIds(Dictionary<int, string>? ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
 
-    public NullableDictionaryParameterTestBuilder WithEmptyIds()
-    {
-        return WithIds(new Dictionary<int, string>());
-    }
+                   public NullableDictionaryParameterTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(new Dictionary<int, string>());
+                   }
 
-    public NullableDictionaryParameterTestBuilder WithoutIds()
-    {
-        return WithIds(null);
-    }
-}";
+                   public NullableDictionaryParameterTestBuilder WithoutIds()
+                   {
+                       return WithIds(null);
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/NullableDictionaryWithSecondArgNullableParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/NullableDictionaryWithSecondArgNullableParameterTest.cs
@@ -11,29 +11,31 @@ public class NullableDictionaryWithSecondArgNullableParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class NullableDictionaryWithSecondArgNullableParameterTestBuilder : DomainTestBuilderBase<NullableDictionaryWithSecondArgNullableParameterTest>
-{
-    public NullableDictionaryWithSecondArgNullableParameterTestBuilder WithIds(Dictionary<int, string?>? ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class NullableDictionaryWithSecondArgNullableParameterTestBuilder : DomainTestBuilderBase<NullableDictionaryWithSecondArgNullableParameterTest>
+               {
+                   public NullableDictionaryWithSecondArgNullableParameterTestBuilder WithIds(Dictionary<int, string?>? ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
 
-    public NullableDictionaryWithSecondArgNullableParameterTestBuilder WithEmptyIds()
-    {
-        return WithIds(new Dictionary<int, string?>());
-    }
+                   public NullableDictionaryWithSecondArgNullableParameterTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(new Dictionary<int, string?>());
+                   }
 
-    public NullableDictionaryWithSecondArgNullableParameterTestBuilder WithoutIds()
-    {
-        return WithIds(null);
-    }
-}";
+                   public NullableDictionaryWithSecondArgNullableParameterTestBuilder WithoutIds()
+                   {
+                       return WithIds(null);
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/NullableEnumerableInEnumerableParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/NullableEnumerableInEnumerableParameterTest.cs
@@ -11,24 +11,27 @@ public class NullableEnumerableInEnumerableParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using System.Linq;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class NullableEnumerableInEnumerableParameterTestBuilder : DomainTestBuilderBase<NullableEnumerableInEnumerableParameterTest>
-{
-    public NullableEnumerableInEnumerableParameterTestBuilder WithIds(IEnumerable<IEnumerable<int>?> ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
-
-    public NullableEnumerableInEnumerableParameterTestBuilder WithEmptyIds()
-    {
-        return WithIds(Enumerable.Empty<IEnumerable<int>?>());
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class NullableEnumerableInEnumerableParameterTestBuilder : DomainTestBuilderBase<NullableEnumerableInEnumerableParameterTest>
+               {
+                   public NullableEnumerableInEnumerableParameterTestBuilder WithIds(IEnumerable<IEnumerable<int>?> ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
+               
+                   public NullableEnumerableInEnumerableParameterTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(Enumerable.Empty<IEnumerable<int>?>());
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/NullableEnumerableParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/NullableEnumerableParameterTest.cs
@@ -11,29 +11,32 @@ public class NullableEnumerableParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using System.Linq;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class NullableEnumerableParameterTestBuilder : DomainTestBuilderBase<NullableEnumerableParameterTest>
-{
-    public NullableEnumerableParameterTestBuilder WithIds(IEnumerable<int>? ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class NullableEnumerableParameterTestBuilder : DomainTestBuilderBase<NullableEnumerableParameterTest>
+               {
+                   public NullableEnumerableParameterTestBuilder WithIds(IEnumerable<int>? ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
 
-    public NullableEnumerableParameterTestBuilder WithEmptyIds()
-    {
-        return WithIds(Enumerable.Empty<int>());
-    }
+                   public NullableEnumerableParameterTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(Enumerable.Empty<int>());
+                   }
 
-    public NullableEnumerableParameterTestBuilder WithoutIds()
-    {
-        return WithIds(null);
-    }
-}";
+                   public NullableEnumerableParameterTestBuilder WithoutIds()
+                   {
+                       return WithIds(null);
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/NullableEnumerableWithNullableArgParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/NullableEnumerableWithNullableArgParameterTest.cs
@@ -11,29 +11,32 @@ public class NullableEnumerableWithNullableArgParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using System.Linq;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class NullableEnumerableWithNullableArgParameterTestBuilder : DomainTestBuilderBase<NullableEnumerableWithNullableArgParameterTest>
-{
-    public NullableEnumerableWithNullableArgParameterTestBuilder WithIds(IEnumerable<int?>? ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class NullableEnumerableWithNullableArgParameterTestBuilder : DomainTestBuilderBase<NullableEnumerableWithNullableArgParameterTest>
+               {
+                   public NullableEnumerableWithNullableArgParameterTestBuilder WithIds(IEnumerable<int?>? ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
 
-    public NullableEnumerableWithNullableArgParameterTestBuilder WithEmptyIds()
-    {
-        return WithIds(Enumerable.Empty<int?>());
-    }
+                   public NullableEnumerableWithNullableArgParameterTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(Enumerable.Empty<int?>());
+                   }
 
-    public NullableEnumerableWithNullableArgParameterTestBuilder WithoutIds()
-    {
-        return WithIds(null);
-    }
-}";
+                   public NullableEnumerableWithNullableArgParameterTestBuilder WithoutIds()
+                   {
+                       return WithIds(null);
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/NullableIntParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/NullableIntParameterTest.cs
@@ -11,23 +11,25 @@ public class NullableIntParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class NullableIntParameterTestBuilder : DomainTestBuilderBase<NullableIntParameterTest>
-{
-    public NullableIntParameterTestBuilder WithId(int? id)
-    {
-        FillConstructorWith(nameof(id), id);
-        return this;
-    }
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class NullableIntParameterTestBuilder : DomainTestBuilderBase<NullableIntParameterTest>
+               {
+                   public NullableIntParameterTestBuilder WithId(int? id)
+                   {
+                       FillConstructorWith(nameof(id), id);
+                       return this;
+                   }
 
-    public NullableIntParameterTestBuilder WithoutId()
-    {
-        return WithId(null);
-    }
-}";
+                   public NullableIntParameterTestBuilder WithoutId()
+                   {
+                       return WithId(null);
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/SingleGenericInDoubleGenericParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/SingleGenericInDoubleGenericParameterTest.cs
@@ -13,19 +13,21 @@ public class SingleGenericInDoubleGenericParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class SingleGenericInDoubleGenericParameterTestBuilder : DomainTestBuilderBase<SingleGenericInDoubleGenericParameterTest>
-{
-    public SingleGenericInDoubleGenericParameterTestBuilder WithIds(DoubleGeneric<SingleGeneric<short>, decimal> ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class SingleGenericInDoubleGenericParameterTestBuilder : DomainTestBuilderBase<SingleGenericInDoubleGenericParameterTest>
+               {
+                   public SingleGenericInDoubleGenericParameterTestBuilder WithIds(DoubleGeneric<SingleGeneric<short>, decimal> ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/SingleGenericParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CtorParameterModule/SingleGenericParameterTest.cs
@@ -13,19 +13,21 @@ public class SingleGenericParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CtorParameterModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
-public class SingleGenericParameterTestBuilder : DomainTestBuilderBase<SingleGenericParameterTest>
-{
-    public SingleGenericParameterTestBuilder WithIds(SingleGeneric<char> ids)
-    {
-        FillConstructorWith(nameof(ids), ids);
-        return this;
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CtorParameterModule;
+               public class SingleGenericParameterTestBuilder : DomainTestBuilderBase<SingleGenericParameterTest>
+               {
+                   public SingleGenericParameterTestBuilder WithIds(SingleGeneric<char> ids)
+                   {
+                       FillConstructorWith(nameof(ids), ids);
+                       return this;
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CustomizedBuilderName/WithClassNamePatternTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CustomizedBuilderName/WithClassNamePatternTest.cs
@@ -4,13 +4,15 @@ public class WithClassNamePatternTest
 {
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CustomizedBuilderName;
+        return """
+               using Superclass.Namespace;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CustomizedBuilderName;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CustomizedBuilderName;
-public class WithClassNamePatternTestEntityBuilder : DomainTestBuilderBase<WithClassNamePatternTest>
-{
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CustomizedBuilderName;
+               public class WithClassNamePatternTestEntityBuilder : DomainTestBuilderBase<WithClassNamePatternTest>
+               {
+               }
+               """;
     }
 
     public static string GetBuilderNamePattern()

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CustomizedBuilderName/WithStaticClassNamePatternTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CustomizedBuilderName/WithStaticClassNamePatternTest.cs
@@ -4,13 +4,15 @@ public class WithStaticClassNamePatternTest
 {
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CustomizedBuilderName;
+        return """
+               using Superclass.Namespace;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CustomizedBuilderName;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CustomizedBuilderName;
-public class EntityBuilder : DomainTestBuilderBase<WithStaticClassNamePatternTest>
-{
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CustomizedBuilderName;
+               public class EntityBuilder : DomainTestBuilderBase<WithStaticClassNamePatternTest>
+               {
+               }
+               """;
     }
 
     public static string GetBuilderNamePattern()

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CustomizedBuilderName/WithoutClassNamePatternTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/CustomizedBuilderName/WithoutClassNamePatternTest.cs
@@ -4,13 +4,15 @@ public class WithoutClassNamePatternTest
 {
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CustomizedBuilderName;
+        return """
+               using Superclass.Namespace;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.CustomizedBuilderName;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CustomizedBuilderName;
-public class WithoutClassNamePatternTestBuilder : DomainTestBuilderBase<WithoutClassNamePatternTest>
-{
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.CustomizedBuilderName;
+               public class WithoutClassNamePatternTestBuilder : DomainTestBuilderBase<WithoutClassNamePatternTest>
+               {
+               }
+               """;
     }
 
     public static string? GetBuilderNamePattern()

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/ExistingFile/ExistingFileTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/ExistingFile/ExistingFileTest.cs
@@ -6,35 +6,39 @@ public class ExistingFileTest
 
     public static string GetExistingBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.ExistingFile;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.ExistingFile;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.ExistingFile;
-public class ExistingFileTestBuilder : DomainTestBuilderBase<ExistingFileTest>
-{
-    public ExistingFileTestBuilder WithId2(bool id)
-    {
-        FillPropertyWith(p => p.Id, id);
-        return this;
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.ExistingFile;
+               public class ExistingFileTestBuilder : DomainTestBuilderBase<ExistingFileTest>
+               {
+                   public ExistingFileTestBuilder WithId2(bool id)
+                   {
+                       FillPropertyWith(p => p.Id, id);
+                       return this;
+                   }
+               }
+               """;
     }
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.ExistingFile;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.ExistingFile;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.ExistingFile;
-public class ExistingFileTestBuilder : DomainTestBuilderBase<ExistingFileTest>
-{
-    public ExistingFileTestBuilder WithId(bool id)
-    {
-        FillPropertyWith(p => p.Id, id);
-        return this;
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.ExistingFile;
+               public class ExistingFileTestBuilder : DomainTestBuilderBase<ExistingFileTest>
+               {
+                   public ExistingFileTestBuilder WithId(bool id)
+                   {
+                       FillPropertyWith(p => p.Id, id);
+                       return this;
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/ExistingFile/ExistingFileWithMethodToKeepTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/ExistingFile/ExistingFileWithMethodToKeepTest.cs
@@ -6,43 +6,47 @@ public class ExistingFileWithMethodToKeepTest
 
     public static string GetExistingBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.ExistingFile;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.ExistingFile;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.ExistingFile;
-public class ExistingFileWithMethodToKeepTestBuilder : DomainTestBuilderBase<ExistingFileWithMethodToKeepTest>
-{
-    // tcg keep
-    public ExistingFileWithMethodToKeepTestBuilder WithName(string name)
-    {
-        FillPropertyWith(p => p.Name, name);
-        return this;
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.ExistingFile;
+               public class ExistingFileWithMethodToKeepTestBuilder : DomainTestBuilderBase<ExistingFileWithMethodToKeepTest>
+               {
+                   // tcg keep
+                   public ExistingFileWithMethodToKeepTestBuilder WithName(string name)
+                   {
+                       FillPropertyWith(p => p.Name, name);
+                       return this;
+                   }
+               }
+               """;
     }
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.ExistingFile;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.ExistingFile;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.ExistingFile;
-public class ExistingFileWithMethodToKeepTestBuilder : DomainTestBuilderBase<ExistingFileWithMethodToKeepTest>
-{
-    // tcg keep
-    public ExistingFileWithMethodToKeepTestBuilder WithName(string name)
-    {
-        FillPropertyWith(p => p.Name, name);
-        return this;
-    }
-
-    public ExistingFileWithMethodToKeepTestBuilder WithId(bool id)
-    {
-        FillPropertyWith(p => p.Id, id);
-        return this;
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.ExistingFile;
+               public class ExistingFileWithMethodToKeepTestBuilder : DomainTestBuilderBase<ExistingFileWithMethodToKeepTest>
+               {
+                   // tcg keep
+                   public ExistingFileWithMethodToKeepTestBuilder WithName(string name)
+                   {
+                       FillPropertyWith(p => p.Name, name);
+                       return this;
+                   }
+               
+                   public ExistingFileWithMethodToKeepTestBuilder WithId(bool id)
+                   {
+                       FillPropertyWith(p => p.Id, id);
+                       return this;
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/BoolPropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/BoolPropertyTest.cs
@@ -6,18 +6,20 @@ public class BoolPropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class BoolPropertyTestBuilder : DomainTestBuilderBase<BoolPropertyTest>
-{
-    public BoolPropertyTestBuilder WithId(bool id)
-    {
-        FillPropertyWith(p => p.Id, id);
-        return this;
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class BoolPropertyTestBuilder : DomainTestBuilderBase<BoolPropertyTest>
+               {
+                   public BoolPropertyTestBuilder WithId(bool id)
+                   {
+                       FillPropertyWith(p => p.Id, id);
+                       return this;
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/DictionaryPropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/DictionaryPropertyTest.cs
@@ -6,24 +6,26 @@ public class DictionaryPropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class DictionaryPropertyTestBuilder : DomainTestBuilderBase<DictionaryPropertyTest>
-{
-    public DictionaryPropertyTestBuilder WithIds(Dictionary<int, string> ids)
-    {
-        FillPropertyWith(p => p.Ids, ids);
-        return this;
-    }
-
-    public DictionaryPropertyTestBuilder WithEmptyIds()
-    {
-        return WithIds(new Dictionary<int, string>());
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class DictionaryPropertyTestBuilder : DomainTestBuilderBase<DictionaryPropertyTest>
+               {
+                   public DictionaryPropertyTestBuilder WithIds(Dictionary<int, string> ids)
+                   {
+                       FillPropertyWith(p => p.Ids, ids);
+                       return this;
+                   }
+               
+                   public DictionaryPropertyTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(new Dictionary<int, string>());
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/DoubleGenericInEnumerablePropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/DoubleGenericInEnumerablePropertyTest.cs
@@ -8,25 +8,28 @@ public class DoubleGenericInEnumerablePropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using System.Linq;
+               using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class DoubleGenericInEnumerablePropertyTestBuilder : DomainTestBuilderBase<DoubleGenericInEnumerablePropertyTest>
-{
-    public DoubleGenericInEnumerablePropertyTestBuilder WithIds(IEnumerable<DoubleGeneric<char, long>> ids)
-    {
-        FillPropertyWith(p => p.Ids, ids);
-        return this;
-    }
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class DoubleGenericInEnumerablePropertyTestBuilder : DomainTestBuilderBase<DoubleGenericInEnumerablePropertyTest>
+               {
+                   public DoubleGenericInEnumerablePropertyTestBuilder WithIds(IEnumerable<DoubleGeneric<char, long>> ids)
+                   {
+                       FillPropertyWith(p => p.Ids, ids);
+                       return this;
+                   }
 
-    public DoubleGenericInEnumerablePropertyTestBuilder WithEmptyIds()
-    {
-        return WithIds(Enumerable.Empty<DoubleGeneric<char, long>>());
-    }
-}";
+                   public DoubleGenericInEnumerablePropertyTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(Enumerable.Empty<DoubleGeneric<char, long>>());
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/DoubleGenericPropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/DoubleGenericPropertyTest.cs
@@ -8,19 +8,21 @@ public class DoubleGenericPropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class DoubleGenericPropertyTestBuilder : DomainTestBuilderBase<DoubleGenericPropertyTest>
-{
-    public DoubleGenericPropertyTestBuilder WithIds(DoubleGeneric<char, decimal> ids)
-    {
-        FillPropertyWith(p => p.Ids, ids);
-        return this;
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class DoubleGenericPropertyTestBuilder : DomainTestBuilderBase<DoubleGenericPropertyTest>
+               {
+                   public DoubleGenericPropertyTestBuilder WithIds(DoubleGeneric<char, decimal> ids)
+                   {
+                       FillPropertyWith(p => p.Ids, ids);
+                       return this;
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/EnumerableInEnumerablePropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/EnumerableInEnumerablePropertyTest.cs
@@ -6,24 +6,27 @@ public class EnumerableInEnumerablePropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using System.Linq;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class EnumerableInEnumerablePropertyTestBuilder : DomainTestBuilderBase<EnumerableInEnumerablePropertyTest>
-{
-    public EnumerableInEnumerablePropertyTestBuilder WithIds(IEnumerable<IEnumerable<int>> ids)
-    {
-        FillPropertyWith(p => p.Ids, ids);
-        return this;
-    }
-
-    public EnumerableInEnumerablePropertyTestBuilder WithEmptyIds()
-    {
-        return WithIds(Enumerable.Empty<IEnumerable<int>>());
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class EnumerableInEnumerablePropertyTestBuilder : DomainTestBuilderBase<EnumerableInEnumerablePropertyTest>
+               {
+                   public EnumerableInEnumerablePropertyTestBuilder WithIds(IEnumerable<IEnumerable<int>> ids)
+                   {
+                       FillPropertyWith(p => p.Ids, ids);
+                       return this;
+                   }
+               
+                   public EnumerableInEnumerablePropertyTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(Enumerable.Empty<IEnumerable<int>>());
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/EnumerableInListPropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/EnumerableInListPropertyTest.cs
@@ -6,24 +6,26 @@ public class EnumerableInListPropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class EnumerableInListPropertyTestBuilder : DomainTestBuilderBase<EnumerableInListPropertyTest>
-{
-    public EnumerableInListPropertyTestBuilder WithIds(List<IEnumerable<int>> ids)
-    {
-        FillPropertyWith(p => p.Ids, ids);
-        return this;
-    }
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class EnumerableInListPropertyTestBuilder : DomainTestBuilderBase<EnumerableInListPropertyTest>
+               {
+                   public EnumerableInListPropertyTestBuilder WithIds(List<IEnumerable<int>> ids)
+                   {
+                       FillPropertyWith(p => p.Ids, ids);
+                       return this;
+                   }
 
-    public EnumerableInListPropertyTestBuilder WithEmptyIds()
-    {
-        return WithIds(new List<IEnumerable<int>>());
-    }
-}";
+                   public EnumerableInListPropertyTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(new List<IEnumerable<int>>());
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/EnumerablePropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/EnumerablePropertyTest.cs
@@ -6,24 +6,27 @@ public class EnumerablePropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using System.Linq;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class EnumerablePropertyTestBuilder : DomainTestBuilderBase<EnumerablePropertyTest>
-{
-    public EnumerablePropertyTestBuilder WithIds(IEnumerable<int> ids)
-    {
-        FillPropertyWith(p => p.Ids, ids);
-        return this;
-    }
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class EnumerablePropertyTestBuilder : DomainTestBuilderBase<EnumerablePropertyTest>
+               {
+                   public EnumerablePropertyTestBuilder WithIds(IEnumerable<int> ids)
+                   {
+                       FillPropertyWith(p => p.Ids, ids);
+                       return this;
+                   }
 
-    public EnumerablePropertyTestBuilder WithEmptyIds()
-    {
-        return WithIds(Enumerable.Empty<int>());
-    }
-}";
+                   public EnumerablePropertyTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(Enumerable.Empty<int>());
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/GetOnlyPropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/GetOnlyPropertyTest.cs
@@ -6,12 +6,14 @@ public class GetOnlyPropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class GetOnlyPropertyTestBuilder : DomainTestBuilderBase<GetOnlyPropertyTest>
-{
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class GetOnlyPropertyTestBuilder : DomainTestBuilderBase<GetOnlyPropertyTest>
+               {
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/InheritFromIEnumerableWithStandardCtorPropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/InheritFromIEnumerableWithStandardCtorPropertyTest.cs
@@ -8,23 +8,25 @@ public class InheritFromIEnumerableWithStandardCtorPropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class InheritFromIEnumerableWithStandardCtorPropertyTestBuilder : DomainTestBuilderBase<InheritFromIEnumerableWithStandardCtorPropertyTest>
-{
-    public InheritFromIEnumerableWithStandardCtorPropertyTestBuilder WithIds(InheritFromIEnumerableWithStandardCtor ids)
-    {
-        FillPropertyWith(p => p.Ids, ids);
-        return this;
-    }
-
-    public InheritFromIEnumerableWithStandardCtorPropertyTestBuilder WithEmptyIds()
-    {
-        return WithIds(new InheritFromIEnumerableWithStandardCtor());
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class InheritFromIEnumerableWithStandardCtorPropertyTestBuilder : DomainTestBuilderBase<InheritFromIEnumerableWithStandardCtorPropertyTest>
+               {
+                   public InheritFromIEnumerableWithStandardCtorPropertyTestBuilder WithIds(InheritFromIEnumerableWithStandardCtor ids)
+                   {
+                       FillPropertyWith(p => p.Ids, ids);
+                       return this;
+                   }
+               
+                   public InheritFromIEnumerableWithStandardCtorPropertyTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(new InheritFromIEnumerableWithStandardCtor());
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/InheritFromIEnumerableWithoutStandardCtorPropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/InheritFromIEnumerableWithoutStandardCtorPropertyTest.cs
@@ -8,18 +8,20 @@ public class InheritFromIEnumerableWithoutStandardCtorPropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class InheritFromIEnumerableWithoutStandardCtorPropertyTestBuilder : DomainTestBuilderBase<InheritFromIEnumerableWithoutStandardCtorPropertyTest>
-{
-    public InheritFromIEnumerableWithoutStandardCtorPropertyTestBuilder WithIds(InheritFromIEnumerableWithoutStandardCtor ids)
-    {
-        FillPropertyWith(p => p.Ids, ids);
-        return this;
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class InheritFromIEnumerableWithoutStandardCtorPropertyTestBuilder : DomainTestBuilderBase<InheritFromIEnumerableWithoutStandardCtorPropertyTest>
+               {
+                   public InheritFromIEnumerableWithoutStandardCtorPropertyTestBuilder WithIds(InheritFromIEnumerableWithoutStandardCtor ids)
+                   {
+                       FillPropertyWith(p => p.Ids, ids);
+                       return this;
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/IntPropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/IntPropertyTest.cs
@@ -6,18 +6,20 @@ public class IntPropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class IntPropertyTestBuilder : DomainTestBuilderBase<IntPropertyTest>
-{
-    public IntPropertyTestBuilder WithId(int id)
-    {
-        FillPropertyWith(p => p.Id, id);
-        return this;
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class IntPropertyTestBuilder : DomainTestBuilderBase<IntPropertyTest>
+               {
+                   public IntPropertyTestBuilder WithId(int id)
+                   {
+                       FillPropertyWith(p => p.Id, id);
+                       return this;
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/ListInEnumerablePropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/ListInEnumerablePropertyTest.cs
@@ -6,24 +6,27 @@ public class ListInEnumerablePropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using System.Linq;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class ListInEnumerablePropertyTestBuilder : DomainTestBuilderBase<ListInEnumerablePropertyTest>
-{
-    public ListInEnumerablePropertyTestBuilder WithIds(IEnumerable<List<int>?> ids)
-    {
-        FillPropertyWith(p => p.Ids, ids);
-        return this;
-    }
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class ListInEnumerablePropertyTestBuilder : DomainTestBuilderBase<ListInEnumerablePropertyTest>
+               {
+                   public ListInEnumerablePropertyTestBuilder WithIds(IEnumerable<List<int>?> ids)
+                   {
+                       FillPropertyWith(p => p.Ids, ids);
+                       return this;
+                   }
 
-    public ListInEnumerablePropertyTestBuilder WithEmptyIds()
-    {
-        return WithIds(Enumerable.Empty<List<int>?>());
-    }
-}";
+                   public ListInEnumerablePropertyTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(Enumerable.Empty<List<int>?>());
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/ListPropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/ListPropertyTest.cs
@@ -6,24 +6,26 @@ public class ListPropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class ListPropertyTestBuilder : DomainTestBuilderBase<ListPropertyTest>
-{
-    public ListPropertyTestBuilder WithIds(List<int> ids)
-    {
-        FillPropertyWith(p => p.Ids, ids);
-        return this;
-    }
-
-    public ListPropertyTestBuilder WithEmptyIds()
-    {
-        return WithIds(new List<int>());
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class ListPropertyTestBuilder : DomainTestBuilderBase<ListPropertyTest>
+               {
+                   public ListPropertyTestBuilder WithIds(List<int> ids)
+                   {
+                       FillPropertyWith(p => p.Ids, ids);
+                       return this;
+                   }
+               
+                   public ListPropertyTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(new List<int>());
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/NullableDictionaryPropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/NullableDictionaryPropertyTest.cs
@@ -6,29 +6,31 @@ public class NullableDictionaryPropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class NullableDictionaryPropertyTestBuilder : DomainTestBuilderBase<NullableDictionaryPropertyTest>
-{
-    public NullableDictionaryPropertyTestBuilder WithIds(Dictionary<int, string>? ids)
-    {
-        FillPropertyWith(p => p.Ids, ids);
-        return this;
-    }
-
-    public NullableDictionaryPropertyTestBuilder WithEmptyIds()
-    {
-        return WithIds(new Dictionary<int, string>());
-    }
-
-    public NullableDictionaryPropertyTestBuilder WithoutIds()
-    {
-        return WithIds(null);
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class NullableDictionaryPropertyTestBuilder : DomainTestBuilderBase<NullableDictionaryPropertyTest>
+               {
+                   public NullableDictionaryPropertyTestBuilder WithIds(Dictionary<int, string>? ids)
+                   {
+                       FillPropertyWith(p => p.Ids, ids);
+                       return this;
+                   }
+               
+                   public NullableDictionaryPropertyTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(new Dictionary<int, string>());
+                   }
+               
+                   public NullableDictionaryPropertyTestBuilder WithoutIds()
+                   {
+                       return WithIds(null);
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/NullableDictionaryWithSecondArgNullablePropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/NullableDictionaryWithSecondArgNullablePropertyTest.cs
@@ -6,29 +6,31 @@ public class NullableDictionaryWithSecondArgNullablePropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class NullableDictionaryWithSecondArgNullablePropertyTestBuilder : DomainTestBuilderBase<NullableDictionaryWithSecondArgNullablePropertyTest>
-{
-    public NullableDictionaryWithSecondArgNullablePropertyTestBuilder WithIds(Dictionary<int, string?>? ids)
-    {
-        FillPropertyWith(p => p.Ids, ids);
-        return this;
-    }
-
-    public NullableDictionaryWithSecondArgNullablePropertyTestBuilder WithEmptyIds()
-    {
-        return WithIds(new Dictionary<int, string?>());
-    }
-
-    public NullableDictionaryWithSecondArgNullablePropertyTestBuilder WithoutIds()
-    {
-        return WithIds(null);
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class NullableDictionaryWithSecondArgNullablePropertyTestBuilder : DomainTestBuilderBase<NullableDictionaryWithSecondArgNullablePropertyTest>
+               {
+                   public NullableDictionaryWithSecondArgNullablePropertyTestBuilder WithIds(Dictionary<int, string?>? ids)
+                   {
+                       FillPropertyWith(p => p.Ids, ids);
+                       return this;
+                   }
+               
+                   public NullableDictionaryWithSecondArgNullablePropertyTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(new Dictionary<int, string?>());
+                   }
+               
+                   public NullableDictionaryWithSecondArgNullablePropertyTestBuilder WithoutIds()
+                   {
+                       return WithIds(null);
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/NullableEnumerableInEnumerablePropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/NullableEnumerableInEnumerablePropertyTest.cs
@@ -6,24 +6,27 @@ public class NullableEnumerableInEnumerablePropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using System.Linq;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class NullableEnumerableInEnumerablePropertyTestBuilder : DomainTestBuilderBase<NullableEnumerableInEnumerablePropertyTest>
-{
-    public NullableEnumerableInEnumerablePropertyTestBuilder WithIds(IEnumerable<IEnumerable<int>?> ids)
-    {
-        FillPropertyWith(p => p.Ids, ids);
-        return this;
-    }
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class NullableEnumerableInEnumerablePropertyTestBuilder : DomainTestBuilderBase<NullableEnumerableInEnumerablePropertyTest>
+               {
+                   public NullableEnumerableInEnumerablePropertyTestBuilder WithIds(IEnumerable<IEnumerable<int>?> ids)
+                   {
+                       FillPropertyWith(p => p.Ids, ids);
+                       return this;
+                   }
 
-    public NullableEnumerableInEnumerablePropertyTestBuilder WithEmptyIds()
-    {
-        return WithIds(Enumerable.Empty<IEnumerable<int>?>());
-    }
-}";
+                   public NullableEnumerableInEnumerablePropertyTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(Enumerable.Empty<IEnumerable<int>?>());
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/NullableEnumerablePropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/NullableEnumerablePropertyTest.cs
@@ -6,29 +6,32 @@ public class NullableEnumerablePropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using System.Linq;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class NullableEnumerablePropertyTestBuilder : DomainTestBuilderBase<NullableEnumerablePropertyTest>
-{
-    public NullableEnumerablePropertyTestBuilder WithIds(IEnumerable<int>? ids)
-    {
-        FillPropertyWith(p => p.Ids, ids);
-        return this;
-    }
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class NullableEnumerablePropertyTestBuilder : DomainTestBuilderBase<NullableEnumerablePropertyTest>
+               {
+                   public NullableEnumerablePropertyTestBuilder WithIds(IEnumerable<int>? ids)
+                   {
+                       FillPropertyWith(p => p.Ids, ids);
+                       return this;
+                   }
 
-    public NullableEnumerablePropertyTestBuilder WithEmptyIds()
-    {
-        return WithIds(Enumerable.Empty<int>());
-    }
+                   public NullableEnumerablePropertyTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(Enumerable.Empty<int>());
+                   }
 
-    public NullableEnumerablePropertyTestBuilder WithoutIds()
-    {
-        return WithIds(null);
-    }
-}";
+                   public NullableEnumerablePropertyTestBuilder WithoutIds()
+                   {
+                       return WithIds(null);
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/NullableEnumerableWithNullableArgPropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/NullableEnumerableWithNullableArgPropertyTest.cs
@@ -6,29 +6,32 @@ public class NullableEnumerableWithNullableArgPropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using System.Collections.Generic;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using System.Collections.Generic;
+               using System.Linq;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class NullableEnumerableWithNullableArgPropertyTestBuilder : DomainTestBuilderBase<NullableEnumerableWithNullableArgPropertyTest>
-{
-    public NullableEnumerableWithNullableArgPropertyTestBuilder WithIds(IEnumerable<int?>? ids)
-    {
-        FillPropertyWith(p => p.Ids, ids);
-        return this;
-    }
-
-    public NullableEnumerableWithNullableArgPropertyTestBuilder WithEmptyIds()
-    {
-        return WithIds(Enumerable.Empty<int?>());
-    }
-
-    public NullableEnumerableWithNullableArgPropertyTestBuilder WithoutIds()
-    {
-        return WithIds(null);
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class NullableEnumerableWithNullableArgPropertyTestBuilder : DomainTestBuilderBase<NullableEnumerableWithNullableArgPropertyTest>
+               {
+                   public NullableEnumerableWithNullableArgPropertyTestBuilder WithIds(IEnumerable<int?>? ids)
+                   {
+                       FillPropertyWith(p => p.Ids, ids);
+                       return this;
+                   }
+               
+                   public NullableEnumerableWithNullableArgPropertyTestBuilder WithEmptyIds()
+                   {
+                       return WithIds(Enumerable.Empty<int?>());
+                   }
+               
+                   public NullableEnumerableWithNullableArgPropertyTestBuilder WithoutIds()
+                   {
+                       return WithIds(null);
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/NullableIntPropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/NullableIntPropertyTest.cs
@@ -6,23 +6,25 @@ public class NullableIntPropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class NullableIntPropertyTestBuilder : DomainTestBuilderBase<NullableIntPropertyTest>
-{
-    public NullableIntPropertyTestBuilder WithId(int? id)
-    {
-        FillPropertyWith(p => p.Id, id);
-        return this;
-    }
-
-    public NullableIntPropertyTestBuilder WithoutId()
-    {
-        return WithId(null);
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class NullableIntPropertyTestBuilder : DomainTestBuilderBase<NullableIntPropertyTest>
+               {
+                   public NullableIntPropertyTestBuilder WithId(int? id)
+                   {
+                       FillPropertyWith(p => p.Id, id);
+                       return this;
+                   }
+               
+                   public NullableIntPropertyTestBuilder WithoutId()
+                   {
+                       return WithId(null);
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/PrivatePropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/PrivatePropertyTest.cs
@@ -6,12 +6,14 @@ public class PrivatePropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class PrivatePropertyTestBuilder : DomainTestBuilderBase<PrivatePropertyTest>
-{
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class PrivatePropertyTestBuilder : DomainTestBuilderBase<PrivatePropertyTest>
+               {
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/PrivateSetPropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/PrivateSetPropertyTest.cs
@@ -6,12 +6,14 @@ public class PrivateSetPropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class PrivateSetPropertyTestBuilder : DomainTestBuilderBase<PrivateSetPropertyTest>
-{
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class PrivateSetPropertyTestBuilder : DomainTestBuilderBase<PrivateSetPropertyTest>
+               {
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/SingleGenericInDoubleGenericPropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/SingleGenericInDoubleGenericPropertyTest.cs
@@ -8,19 +8,21 @@ public class SingleGenericInDoubleGenericPropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class SingleGenericInDoubleGenericPropertyTestBuilder : DomainTestBuilderBase<SingleGenericInDoubleGenericPropertyTest>
-{
-    public SingleGenericInDoubleGenericPropertyTestBuilder WithIds(DoubleGeneric<SingleGeneric<short>, decimal> ids)
-    {
-        FillPropertyWith(p => p.Ids, ids);
-        return this;
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class SingleGenericInDoubleGenericPropertyTestBuilder : DomainTestBuilderBase<SingleGenericInDoubleGenericPropertyTest>
+               {
+                   public SingleGenericInDoubleGenericPropertyTestBuilder WithIds(DoubleGeneric<SingleGeneric<short>, decimal> ids)
+                   {
+                       FillPropertyWith(p => p.Ids, ids);
+                       return this;
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/SingleGenericPropertyTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/PublicPropertyModule/SingleGenericPropertyTest.cs
@@ -8,19 +8,21 @@ public class SingleGenericPropertyTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.PublicPropertyModule;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
-public class SingleGenericPropertyTestBuilder : DomainTestBuilderBase<SingleGenericPropertyTest>
-{
-    public SingleGenericPropertyTestBuilder WithIds(SingleGeneric<char> ids)
-    {
-        FillPropertyWith(p => p.Ids, ids);
-        return this;
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.PublicPropertyModule;
+               public class SingleGenericPropertyTestBuilder : DomainTestBuilderBase<SingleGenericPropertyTest>
+               {
+                   public SingleGenericPropertyTestBuilder WithIds(SingleGeneric<char> ids)
+                   {
+                       FillPropertyWith(p => p.Ids, ids);
+                       return this;
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/WithoutNullability/ClassParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/WithoutNullability/ClassParameterTest.cs
@@ -13,23 +13,25 @@ public class ClassParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.WithoutNullability;
+        return """
+               using Superclass.Namespace;
+               using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.WithoutNullability;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.WithoutNullability;
-public class ClassParameterTestBuilder : DomainTestBuilderBase<ClassParameterTest>
-{
-    public ClassParameterTestBuilder WithId(ClassDummy id)
-    {
-        FillConstructorWith(nameof(id), id);
-        return this;
-    }
-
-    public ClassParameterTestBuilder WithoutId()
-    {
-        return WithId(null);
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.WithoutNullability;
+               public class ClassParameterTestBuilder : DomainTestBuilderBase<ClassParameterTest>
+               {
+                   public ClassParameterTestBuilder WithId(ClassDummy id)
+                   {
+                       FillConstructorWith(nameof(id), id);
+                       return this;
+                   }
+               
+                   public ClassParameterTestBuilder WithoutId()
+                   {
+                       return WithId(null);
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/WithoutNullability/IntParameterForNullabilityTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/WithoutNullability/IntParameterForNullabilityTest.cs
@@ -11,18 +11,20 @@ public class IntParameterForNullabilityTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.WithoutNullability;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.WithoutNullability;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.WithoutNullability;
-public class IntParameterForNullabilityTestBuilder : DomainTestBuilderBase<IntParameterForNullabilityTest>
-{
-    public IntParameterForNullabilityTestBuilder WithId(int id)
-    {
-        FillConstructorWith(nameof(id), id);
-        return this;
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.WithoutNullability;
+               public class IntParameterForNullabilityTestBuilder : DomainTestBuilderBase<IntParameterForNullabilityTest>
+               {
+                   public IntParameterForNullabilityTestBuilder WithId(int id)
+                   {
+                       FillConstructorWith(nameof(id), id);
+                       return this;
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/WithoutNullability/NullableIntParameterForNullabilityTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/WithoutNullability/NullableIntParameterForNullabilityTest.cs
@@ -11,23 +11,25 @@ public class NullableIntParameterForNullabilityTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using System;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.WithoutNullability;
+        return """
+               using Superclass.Namespace;
+               using System;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.WithoutNullability;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.WithoutNullability;
-public class NullableIntParameterForNullabilityTestBuilder : DomainTestBuilderBase<NullableIntParameterForNullabilityTest>
-{
-    public NullableIntParameterForNullabilityTestBuilder WithId(int? id)
-    {
-        FillConstructorWith(nameof(id), id);
-        return this;
-    }
-
-    public NullableIntParameterForNullabilityTestBuilder WithoutId()
-    {
-        return WithId(null);
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.WithoutNullability;
+               public class NullableIntParameterForNullabilityTestBuilder : DomainTestBuilderBase<NullableIntParameterForNullabilityTest>
+               {
+                   public NullableIntParameterForNullabilityTestBuilder WithId(int? id)
+                   {
+                       FillConstructorWith(nameof(id), id);
+                       return this;
+                   }
+               
+                   public NullableIntParameterForNullabilityTestBuilder WithoutId()
+                   {
+                       return WithId(null);
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/WithoutNullability/NullableStructParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/WithoutNullability/NullableStructParameterTest.cs
@@ -13,23 +13,25 @@ public class NullableStructParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.WithoutNullability;
+        return """
+               using Superclass.Namespace;
+               using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.WithoutNullability;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.WithoutNullability;
-public class NullableStructParameterTestBuilder : DomainTestBuilderBase<NullableStructParameterTest>
-{
-    public NullableStructParameterTestBuilder WithId(StructDummy? id)
-    {
-        FillConstructorWith(nameof(id), id);
-        return this;
-    }
-
-    public NullableStructParameterTestBuilder WithoutId()
-    {
-        return WithId(null);
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.WithoutNullability;
+               public class NullableStructParameterTestBuilder : DomainTestBuilderBase<NullableStructParameterTest>
+               {
+                   public NullableStructParameterTestBuilder WithId(StructDummy? id)
+                   {
+                       FillConstructorWith(nameof(id), id);
+                       return this;
+                   }
+               
+                   public NullableStructParameterTestBuilder WithoutId()
+                   {
+                       return WithId(null);
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator.Tests/Generators/TestClasses/WithoutNullability/StructParameterTest.cs
+++ b/TestCodeGenerator/Generator.Tests/Generators/TestClasses/WithoutNullability/StructParameterTest.cs
@@ -13,18 +13,20 @@ public class StructParameterTest
 
     public static string GetExpectedBuilder()
     {
-        return @"using Superclass.Namespace;
-using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
-using TestCodeGenerator.Generator.Tests.Generators.TestClasses.WithoutNullability;
+        return """
+               using Superclass.Namespace;
+               using TestCodeGenerator.Generator.Tests.Generators.Subclasses;
+               using TestCodeGenerator.Generator.Tests.Generators.TestClasses.WithoutNullability;
 
-namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.WithoutNullability;
-public class StructParameterTestBuilder : DomainTestBuilderBase<StructParameterTest>
-{
-    public StructParameterTestBuilder WithId(StructDummy id)
-    {
-        FillConstructorWith(nameof(id), id);
-        return this;
-    }
-}";
+               namespace TestCodeGenerator.Generator.Tests.Tests.Generators.TestClasses.WithoutNullability;
+               public class StructParameterTestBuilder : DomainTestBuilderBase<StructParameterTest>
+               {
+                   public StructParameterTestBuilder WithId(StructDummy id)
+                   {
+                       FillConstructorWith(nameof(id), id);
+                       return this;
+                   }
+               }
+               """;
     }
 }

--- a/TestCodeGenerator/Generator/Generators/TestBuilderGenerator.cs
+++ b/TestCodeGenerator/Generator/Generators/TestBuilderGenerator.cs
@@ -52,7 +52,7 @@ public class TestBuilderGenerator
             Console.WriteLine($"Starting code generation for {typeName}");
             var type = types.Single();
 
-            var usings = new Namespaces { _config.GenericSuperclassNamespace, type.Namespace! };
+            var usings = new Usings { _config.GenericSuperclassNamespace, type.Namespace! };
 
             var builderClassName = GenerateBuilderClassName(type);
 
@@ -72,7 +72,7 @@ public class TestBuilderGenerator
         }
     }
 
-    private void UpdateFile(CsFile file, Type type, Namespaces usings, string builderClassName)
+    private void UpdateFile(CsFile file, Type type, Usings usings, string builderClassName)
     {
         var cls = file.Nmsp.Classes.FirstOrDefault(c => c.Name == builderClassName);
 
@@ -101,7 +101,7 @@ public class TestBuilderGenerator
 
         foreach (var @using in usings)
         {
-            file.AddUsing(new Using(@using));
+            file.AddUsing(@using);
         }
 
         file.OrderUsingsAsc();

--- a/TestCodeGenerator/Generator/Models/Usings.cs
+++ b/TestCodeGenerator/Generator/Models/Usings.cs
@@ -1,15 +1,20 @@
-﻿using System.Collections;
+﻿using RefleCS.Nodes;
+using System.Collections;
 
 namespace TestCodeGenerator.Generator.Models;
 
-public class Namespaces : IEnumerable<string>
+public class Usings : IEnumerable<Using>
 {
-    private readonly HashSet<string> _namespaces = new();
+    private readonly HashSet<Using> _namespaces = new();
 
-    public void Add(string nmsp)
+    public void Add(string usng)
     {
-        if (!_namespaces.Contains(nmsp))
-            _namespaces.Add(nmsp);
+        Add(new Using(usng));
+    }
+
+    public void Add(Using usng)
+    {
+        _namespaces.Add(usng);
     }
 
     public void AddRange(IEnumerable<string> namespaces)
@@ -20,7 +25,7 @@ public class Namespaces : IEnumerable<string>
         }
     }
 
-    public IEnumerator<string> GetEnumerator()
+    public IEnumerator<Using> GetEnumerator()
     {
         return _namespaces.GetEnumerator();
     }

--- a/TestCodeGenerator/Generator/Modules/TestBuilder/CtorParameterModule.cs
+++ b/TestCodeGenerator/Generator/Modules/TestBuilder/CtorParameterModule.cs
@@ -11,7 +11,7 @@ public class CtorParameterModule : TestBuilderModuleBase
     {
     }
 
-    public override void Apply(Type type, string builderClassName, Class cls, Namespaces namespaces)
+    public override void Apply(Type type, string builderClassName, Class cls, Usings usings)
     {
         var parameters = new Dictionary<(string, string), ParameterInfo>();
 
@@ -28,7 +28,7 @@ public class CtorParameterModule : TestBuilderModuleBase
         foreach (var info in parameters.Values)
         {
             var nullabilityInfo = new NullabilityInfoContext().Create(info);
-            AddMethods(nullabilityInfo, info.ParameterType, info.Name!, builderClassName, cls, namespaces);
+            AddMethods(nullabilityInfo, info.ParameterType, info.Name!, builderClassName, cls, usings);
         }
     }
 

--- a/TestCodeGenerator/Generator/Modules/TestBuilder/ITestBuilderModule.cs
+++ b/TestCodeGenerator/Generator/Modules/TestBuilder/ITestBuilderModule.cs
@@ -1,10 +1,9 @@
 ﻿using RefleCS.Nodes;
-using TestCodeGenerator.Generator.Generators;
 using TestCodeGenerator.Generator.Models;
 
 namespace TestCodeGenerator.Generator.Modules.TestBuilder;
 
 public interface ITestBuilderModule
 {
-    void Apply(Type type, string builderClassName, Class cls, Namespaces namespaces);
+    void Apply(Type type, string builderClassName, Class cls, Usings namespaces);
 }

--- a/TestCodeGenerator/Generator/Modules/TestBuilder/PublicPropertyModule.cs
+++ b/TestCodeGenerator/Generator/Modules/TestBuilder/PublicPropertyModule.cs
@@ -12,7 +12,7 @@ public class PublicPropertyModule : TestBuilderModuleBase
     {
     }
 
-    public override void Apply(Type type, string builderClassName, Class cls, Namespaces namespaces)
+    public override void Apply(Type type, string builderClassName, Class cls, Usings usings)
     {
         var properties = new Dictionary<(string, string), PropertyInfo>();
 
@@ -29,7 +29,7 @@ public class PublicPropertyModule : TestBuilderModuleBase
         foreach (var info in properties.Values)
         {
             var nullabilityInfo = new NullabilityInfoContext().Create(info);
-            AddMethods(nullabilityInfo, info.PropertyType, info.Name, builderClassName, cls, namespaces);
+            AddMethods(nullabilityInfo, info.PropertyType, info.Name, builderClassName, cls, usings);
         }
     }
 


### PR DESCRIPTION
closes #28 